### PR TITLE
Added the ability to get other users' avatars and see emote usage

### DIFF
--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -1,6 +1,29 @@
 /* eslint-disable no-unused-vars */
 exports.run = async (client, message, args, level) => {
-    message.reply(message.author.avatarURL);
+    // avatar <ping>
+    // NOTE: This MUST come before user id since /\d+/ is more generic.
+    if (args.length >= 1 && /<@.?\d+>/g.test(args[0])) {
+        let targetID = args[0].match(/\d+/g)[0];
+        client.fetchUser(targetID).then(user => {
+            message.reply(user.avatarURL);
+        });
+    }
+    // avatar <user id>
+    else if (args.length >= 1 && /\d+/g.test(args[0])) {
+        client.fetchUser(args[0]).then(user => {
+            message.reply(user.avatarURL);
+        });
+    }
+    // avatar <name with spaces>
+    else if (args.length > 0) {
+        let name = args.join(" ");
+        let user = client.users.find(user => user.username.includes(name));
+        if (user) message.reply(user.avatarURL);
+    }
+    // avatar (no arguments)
+    else {
+        message.reply(message.author.avatarURL);
+    }
 };
 exports.conf = {
     enabled: true,
@@ -11,6 +34,6 @@ exports.conf = {
 exports.help = {
     name: "avatar",
     category: "Fun",
-    description: "Replies with your avatar.",
-    usage: "avatar"
+    description: "Replies with your avatar. You can also search by a user's ID, username, or mention them.",
+    usage: "avatar [id/username/ping]"
 };

--- a/commands/scanemotes.js
+++ b/commands/scanemotes.js
@@ -1,0 +1,101 @@
+/* eslint-disable no-unused-vars */
+exports.run = async (client, message, args, level) => {
+    let stats = {};
+    let statsWithoutBots = {};
+    let allTextChannelsInCurrentGuild = message.guild.channels.filter(channel => channel.type === "text");
+    let channelsSearched = 0;
+    
+    allTextChannelsInCurrentGuild.forEach(async channel => {
+        // This will count all reactions in text and reactions per channel.
+        let selected = channel.lastMessageID;
+        let continueLoop = true;
+        
+        while (continueLoop) {
+            let messages = await channel.fetchMessages({
+                limit: 100,
+                before: selected
+            });
+            
+            if (messages.size <= 0) {
+                continueLoop = false;
+                channelsSearched++;
+                
+                // Display stats on emote usage.
+                if (channelsSearched >= allTextChannelsInCurrentGuild.size) {
+                    // Depending on how many emotes you have, you might have to break up the analytics into multiple messages.
+                    let lines = [];
+                    let line = "";
+                    
+                    for (let emote in stats) {
+                        let emoteObject = message.guild.emojis.get(emote);
+                        
+                        // Emotes not within the current guild (or deleted ones) will return null. Select only those from the current guild.
+                        if (emoteObject != null) {
+                            let stat = emoteObject.toString() + " x " + stats[emote] + " (" + (statsWithoutBots[emote] || 0) + " without bots)\n";
+                            
+                            if (line.length + stat.length > 1900) {
+                                lines.push(line);
+                                line = "";
+                            }
+                            
+                            line += stat;
+                        }
+                    }
+                    
+                    if(line.length > 0) lines.push(line); // You can't send empty messages or there'll be an error.
+                    for(let ln of lines) await message.channel.send(ln);
+                }
+            } else {
+                messages.forEach(msg => {
+                    let msgEmotes = msg.content.match(/<:.+?:\d+?>/g) || [];
+                    let reactionEmotes = msg.reactions.keyArray();
+                    
+                    for (let emote of msgEmotes) {
+                        let emoteID = emote.match(/\d+/g)[0];
+                        
+                        if (!(emoteID in stats)) stats[emoteID] = 0;
+                        stats[emoteID]++;
+                        
+                        if (!msg.author.bot) {
+                            if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
+                            statsWithoutBots[emoteID]++;
+                        }
+                    }
+                    
+                    for (let emoteTag of reactionEmotes) {
+                        let emoteTagIndex = emoteTag.indexOf(":");
+                        let emoteID = emoteTagIndex !== -1 ? emoteTag.substring(emoteTagIndex+1) : emoteTag; // In Discord.js v11, the keys are "<emote name>:<emote ID>" instead.
+                        
+                        // Exclude any unicode emote.
+                        if (msg.reactions.get(emoteTag).emoji.id != null) {
+                            if (!(emoteID in stats)) stats[emoteID] = 0;
+                            stats[emoteID] += msg.reactions.get(emoteTag).count;
+                            
+                            if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
+                            statsWithoutBots[emoteID] += msg.reactions.get(emoteTag).count;
+                            
+                            // I don't know why this collection always appears as empty.
+                            msg.reactions.get(emoteTag).users.forEach(user => {
+                                if (user.bot) statsWithoutBots[emoteID]--;
+                            });
+                        }
+                    }
+                    
+                    selected = msg.id;
+                });
+            }
+        }
+    });
+};
+exports.conf = {
+    enabled: true,
+    guildOnly: false,
+    aliases: [],
+    permLevel: "User"
+};
+exports.help = {
+    name: "scanemotes",
+    category: "Miscellaneous",
+    description: "Scans all text channels in the current guild and returns the number of times each emoji specific to the guild has been used.",
+    usage: "scanemotes"
+};

--- a/commands/serverinfo.js
+++ b/commands/serverinfo.js
@@ -13,7 +13,7 @@ exports.run = async (client, message, args, level) => {
         .addField("**Role Count:**", `${message.guild.roles.size}`, true)
         .setFooter("Travbot Services", client.user.displayAvatarURL);
     message.channel.send({
-        sEmbed
+        embed: sEmbed
     });
 };
 exports.conf = {


### PR DESCRIPTION
- You can now scan the current guild for emote usage, collecting all emotes used in messages and reactions. (example below)
![2020-06-19 04_08_22-Window](https://user-images.githubusercontent.com/44940783/85116219-98a69280-b1e2-11ea-9246-b8f5ff2537ea.png)
- You can now get other avatars by providing an ID (works even when the bot doesn't share the same server as that user), username, or by pinging them.
- Included the fix for `serverinfo`.