### PR TITLE
Hotfix: Scan emotes no longer requires admin

### DIFF
--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -19,6 +19,7 @@ exports.run = async (client, message, args, level) => {
         let name = args.join(" ");
         let user = client.users.find(user => user.username.includes(name));
         if (user) message.reply(user.avatarURL);
+        else message.reply(`No user found by the name \`${name}\`!`);
     }
     // avatar (no arguments)
     else {

--- a/commands/scanemotes.js
+++ b/commands/scanemotes.js
@@ -3,9 +3,19 @@ exports.run = async (client, message, args, level) => {
     let stats = {};
     let statsWithoutBots = {};
     let allTextChannelsInCurrentGuild = message.guild.channels.filter(channel => channel.type === "text");
+    let limit = allTextChannelsInCurrentGuild.size;
     let channelsSearched = 0;
     
     allTextChannelsInCurrentGuild.forEach(async channel => {
+        // IMPORTANT: You MUST check if the bot actually has access to the channel in the first place. It will get the list of all channels, but that doesn't mean it has access to every channel. Without this, it'll require admin access and throw an annoying unhelpful DiscordAPIError: Missing Access otherwise.
+        const permissions = channel.permissionsFor(client.user);
+        const isViewable = permissions && permissions.has("VIEW_CHANNEL", false);
+        
+        if (!isViewable) {
+            limit--;
+            return;
+        }
+        
         // This will count all reactions in text and reactions per channel.
         let selected = channel.lastMessageID;
         let continueLoop = true;
@@ -21,7 +31,7 @@ exports.run = async (client, message, args, level) => {
                 channelsSearched++;
                 
                 // Display stats on emote usage.
-                if (channelsSearched >= allTextChannelsInCurrentGuild.size) {
+                if (channelsSearched >= limit) {
                     // Depending on how many emotes you have, you might have to break up the analytics into multiple messages.
                     let lines = [];
                     let line = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "TravBot Discord bot.",
     "main": "index.js",
     "author": "Keanu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "TravBot Discord bot.",
     "main": "index.js",
     "author": "Keanu",


### PR DESCRIPTION
- Fixed the `scanemotes` command to no longer require admin permissions. This was due to an oversight: There can be channels which the bot doesn't have access to, ie private channels. You have to check if the bot has access to a channel because the filter will gather all text-based channels regardless. Admin permissions overrides all restrictions, which is why it only worked with admin permissions.
- Entering a username in the `avatar` command unsuccessfully will now send a message in chat.
- Bumped version numbers in `package.json` because I kept forgetting to do so.
    - `2.5.1` - `eco` hotfix
    - `2.6.0` - `scanemotes` implementation
    - `2.6.1` - `scanemotes` hotfix