### PR TITLE
Added percentages to scanemotes

### DIFF
--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -3,27 +3,30 @@ exports.run = async (client, message, args, level) => {
     // avatar <ping>
     // NOTE: This MUST come before user id since /\d+/ is more generic.
     if (args.length >= 1 && /<@.?\d+>/g.test(args[0])) {
-        let targetID = args[0].match(/\d+/g)[0];
-        client.fetchUser(targetID).then(user => {
-            message.reply(user.avatarURL);
+        client.fetchUser(args[0].match(/\d+/g)[0]).then(user => {
+            message.channel.send(user.avatarURL);
+        }).catch(error => {
+            message.channel.send(`Something went wrong with finding the user by that ping.\n\`\`\`${error}\`\`\``);
         });
     }
     // avatar <user id>
     else if (args.length >= 1 && /\d+/g.test(args[0])) {
         client.fetchUser(args[0]).then(user => {
-            message.reply(user.avatarURL);
+            message.channel.send(user.avatarURL);
+        }).catch(error => {
+            message.channel.send(`\`${args[0]}\` is an invalid user ID!`);
         });
     }
     // avatar <name with spaces>
     else if (args.length > 0) {
         let name = args.join(" ");
         let user = client.users.find(user => user.username.includes(name));
-        if (user) message.reply(user.avatarURL);
-        else message.reply(`No user found by the name \`${name}\`!`);
+        if (user) message.channel.send(user.avatarURL);
+        else message.channel.send(`No user found by the name \`${name}\`!`);
     }
     // avatar (no arguments)
     else {
-        message.reply(message.author.avatarURL);
+        message.channel.send(message.author.avatarURL);
     }
 };
 exports.conf = {

--- a/commands/eco.js
+++ b/commands/eco.js
@@ -2,14 +2,22 @@
 const Discord = require("discord.js");
 const fs = require("fs");
 const moment = require("moment");
+const obliterate = [
+    "Surprise %%%! KABOOOOOOOOOOM!!!",
+    "%%% has lost their ability to even.",
+    "お前はもう死んでいる､ %%%！",
+    "And thus, it was foretold that %%% shall be obliterated!"
+];
 exports.run = async (client, message, args, level) => {
-    if (message.guild.id != "637512823676600330") return message.channel.send("Sorry, this command can only be used in Monika's emote server.");
+    //if (message.guild.id != "637512823676600330") return message.channel.send("Sorry, this command can only be used in Monika's emote server.");
     const UserData = JSON.parse(fs.readFileSync(__dirname + "/storage/UserData.json", "utf8"));
     const sender = message.author;
-    if (!UserData[sender.id + message.guild.id]) UserData[sender.id + message.guild.id] = {};
-    if (!UserData[sender.id + message.guild.id].money) UserData[sender.id + message.guild.id].money = 1;
-    if (!UserData[sender.id + message.guild.id].lastDaily) UserData[sender.id + message.guild.id].lastDaily = "Not Collected";
-    if (!UserData[sender.id + message.guild.id].userid) UserData[sender.id + message.guild.id].userid = message.author.id;
+    const compositeID = sender.id + message.guild.id;
+    // If you pay someone while you have exactly 1 Mon, your amount of Mons will become 0, but because of JS's soft comparison, that 0 will coerce to false and it'll trigger the default 1 Mon to magically appear in your account. Use the in operator instead to fix this issue.
+    if (!UserData[compositeID]) UserData[compositeID] = {};
+    if (!("money" in UserData[compositeID])) UserData[compositeID].money = 1;
+    if (!UserData[compositeID].lastDaily) UserData[compositeID].lastDaily = "Not Collected";
+    if (!UserData[compositeID].userid) UserData[compositeID].userid = message.author.id;
     // Balance Command
     if (args[0] == "balance" || args[0] == "money") {
         message.channel.send({
@@ -22,19 +30,19 @@ exports.run = async (client, message, args, level) => {
                     inline: true
                 }, {
                     name: "Account Balance",
-                    value: UserData[sender.id + message.guild.id].money,
+                    value: UserData[compositeID].money,
                     inline: true
                 }]
             }
         });
     }
     // Daily Mon Command
-    if (args[0] == "daily") {
-        if (UserData[sender.id + message.guild.id].lastDaily != moment()
+    else if (args[0] == "daily") {
+        if (UserData[compositeID].lastDaily != moment()
             .format("L")) {
-            UserData[sender.id + message.guild.id].lastDaily = moment()
+            UserData[compositeID].lastDaily = moment()
                 .format("L");
-            UserData[sender.id + message.guild.id].money += 1;
+            UserData[compositeID].money += 1;
             message.channel.send({
                 embed: {
                     title: "Daily Reward",
@@ -54,7 +62,7 @@ exports.run = async (client, message, args, level) => {
             });
         }
     }
-    if (args[0] == "guild") {
+    else if (args[0] == "guild") {
         var guildMoney = 0; // Total amount of Mons in guild.
         var guildUsers = 0;
         var guildRichest = ""; // Richest user in guild.
@@ -88,7 +96,7 @@ exports.run = async (client, message, args, level) => {
             }
         });
     }
-    if (args[0] == "pay") {
+    else if (args[0] == "pay") {
         if (!args[1] || !args[2])
             message.channel.send("eco pay <amount> <user> -- Use underscores for spaces (or ping the user alternatively).");
         else if (args.length > 3)
@@ -101,17 +109,15 @@ exports.run = async (client, message, args, level) => {
             else {
                 amount = Math.floor(amount);
 
-                if (amount > UserData[sender.id + message.guild.id].money)
+                if (amount > UserData[compositeID].money)
                     message.channel.send("You don't have enough Mons for that.");
                 else if (amount <= 0)
                     message.channel.send("You must send at least one Mon!");
                 else {
                     var target;
 
-                    if (/<@\d+>/.test(args[2])) {
-                        target = args[2].substring(2, args[2].length - 1);
-                    } else if (/<@!\d+>/.test(args[2])) {
-                        target = args[2].substring(3, args[2].length - 1);
+                    if (/<@.?\d+>/g.test(args[2])) {
+                        target = args[2].match(/\d+/g)[0];
                     } else {
                         var name = args[2].split("_").join(" ");
                         target = client.users.find(user => user.username == name).id;
@@ -127,11 +133,11 @@ exports.run = async (client, message, args, level) => {
 
                             // Initialize target account
                             if (!UserData[account]) UserData[account] = {};
-                            if (!UserData[account].money) UserData[account].money = 1;
+                            if (!("money" in UserData[account])) UserData[account].money = 1;
                             if (!UserData[account].lastDaily) UserData[account].lastDaily = "Not Collected";
                             if (!UserData[account].userid) UserData[account].userid = target;
 
-                            UserData[sender.id + message.guild.id].money -= amount;
+                            UserData[compositeID].money -= amount;
                             UserData[account].money += amount;
                             if (amount > 1) {
                                 message.channel.send(`<@${sender.id}> has sent ${amount} Mons to <@${target}>!`);
@@ -144,42 +150,72 @@ exports.run = async (client, message, args, level) => {
             }
         }
     }
-    if (args[0] == "buy") {
+    else if (args[0] == "buy") {
         if (args[1] == "hug") {
             const amount = 1;
-            if (amount > UserData[sender.id + message.guild.id].money) {
+            if (amount > UserData[compositeID].money) {
                 message.channel.send("Not enough Mons!");
             } else {
-                UserData[sender.id + message.guild.id].money -= amount;
+                UserData[compositeID].money -= amount;
                 message.channel.send(`Transaction of ${amount} Mon completed successfully. <@394808963356688394>`);
             }
         }
-        if (args[1] == "handhold") {
+        else if (args[1] == "handhold") {
             const amount = 2;
-            if (amount > UserData[sender.id + message.guild.id].money) {
+            if (amount > UserData[compositeID].money) {
                 message.channel.send("Not enough Mons!");
             } else {
-                UserData[sender.id + message.guild.id].money -= amount;
+                UserData[compositeID].money -= amount;
                 message.channel.send(`Transaction of ${amount} Mons completed successfully. <@394808963356688394>`);
             }
         }
-        if (args[1] == "cute") {
+        else if (args[1] == "cute") {
             const amount = 1;
-            if (amount > UserData[sender.id + message.guild.id].money) {
+            if (amount > UserData[compositeID].money) {
                 message.channel.send("Not enough Mons!");
             } else {
-                UserData[sender.id + message.guild.id].money -= amount;
+                UserData[compositeID].money -= amount;
                 message.channel.send("<:MoniCheeseBlushRed:637513137083383826>");
             }
         }
+        else if (args[1] == "obliterate") {
+            const amount = 15;
+            if (amount > UserData[compositeID].money) {
+                message.channel.send("Not enough Mons!");
+            } else if (!args[2] || !/<@.?\d+>/g.test(args[2])) {
+                message.channel.send("You need to ping a user to activate this command!");
+            } else {
+                // It's better to use async functions here because it'll work with the data writing at the end.
+                const user = await client.fetchUser(args[2].match(/\d+/g)[0]);
+
+                if (user.bot) {
+                    message.channel.send("no u");
+                } else {
+                    UserData[compositeID].money -= amount;
+                    const target = user.id + message.guild.id;
+                    if (!UserData[target]) UserData[target] = {};
+                    UserData[target].obliterated = Date.now();
+
+                    await message.channel.send(obliterate[Math.floor(Math.random() * obliterate.length)].replace(/%%%/g, user.toString()), {
+                        files: [{
+                            attachment: "assets/TheUltimateLaser.gif"
+                        }]
+                    });
+                }
+            }
+        }
+        else {
+            message.channel.send(`There's no item in the shop that goes by \`${args[1]}\`!`);
+        }
     }
-    if (args[0] == "shop") {
+    else if (args[0] == "shop") {
         const embed = new Discord.RichEmbed()
             .setColor(0xf1c40f)
             .setTitle("Shop")
             .addField("**Hug** (.eco buy hug)", "Hug Monika. Costs 1 Mon.")
             .addField("**Handholding** (.eco buy handhold)", "Hold Monika's hand. Costs 2 Mons.")
             .addField("**Cute** (.eco buy cute)", "Calls Monika cute. Costs 1 Mon.")
+            .addField("**Obliterate** (.eco buy obliterate @user)", "Call upon the demons of Selzar to blast a person of your choice with a laser so powerful that it prevents them from using TravBot for 3 entire days. Costs 15 Mons.")
             .setFooter("Mon Shop | TravBot Services");
         message.channel.send(embed);
     }

--- a/commands/eco.js
+++ b/commands/eco.js
@@ -9,7 +9,7 @@ const obliterate = [
     "And thus, it was foretold that %%% shall be obliterated!"
 ];
 exports.run = async (client, message, args, level) => {
-    //if (message.guild.id != "637512823676600330") return message.channel.send("Sorry, this command can only be used in Monika's emote server.");
+    if (message.guild.id != "637512823676600330") return message.channel.send("Sorry, this command can only be used in Monika's emote server.");
     const UserData = JSON.parse(fs.readFileSync(__dirname + "/storage/UserData.json", "utf8"));
     const sender = message.author;
     const compositeID = sender.id + message.guild.id;
@@ -195,7 +195,6 @@ exports.run = async (client, message, args, level) => {
                     const target = user.id + message.guild.id;
                     if (!UserData[target]) UserData[target] = {};
                     UserData[target].obliterated = Date.now();
-
                     await message.channel.send(obliterate[Math.floor(Math.random() * obliterate.length)].replace(/%%%/g, user.toString()), {
                         files: [{
                             attachment: "assets/TheUltimateLaser.gif"

--- a/commands/eco.js
+++ b/commands/eco.js
@@ -178,31 +178,6 @@ exports.run = async (client, message, args, level) => {
                 message.channel.send("<:MoniCheeseBlushRed:637513137083383826>");
             }
         }
-        else if (args[1] == "obliterate") {
-            const amount = 15;
-            if (amount > UserData[compositeID].money) {
-                message.channel.send("Not enough Mons!");
-            } else if (!args[2] || !/<@.?\d+>/g.test(args[2])) {
-                message.channel.send("You need to ping a user to activate this command!");
-            } else {
-                // It's better to use async functions here because it'll work with the data writing at the end.
-                const user = await client.fetchUser(args[2].match(/\d+/g)[0]);
-
-                if (user.bot) {
-                    message.channel.send("no u");
-                } else {
-                    UserData[compositeID].money -= amount;
-                    const target = user.id + message.guild.id;
-                    if (!UserData[target]) UserData[target] = {};
-                    UserData[target].obliterated = Date.now();
-                    await message.channel.send(obliterate[Math.floor(Math.random() * obliterate.length)].replace(/%%%/g, user.toString()), {
-                        files: [{
-                            attachment: "assets/TheUltimateLaser.gif"
-                        }]
-                    });
-                }
-            }
-        }
         else {
             message.channel.send(`There's no item in the shop that goes by \`${args[1]}\`!`);
         }
@@ -214,7 +189,6 @@ exports.run = async (client, message, args, level) => {
             .addField("**Hug** (.eco buy hug)", "Hug Monika. Costs 1 Mon.")
             .addField("**Handholding** (.eco buy handhold)", "Hold Monika's hand. Costs 2 Mons.")
             .addField("**Cute** (.eco buy cute)", "Calls Monika cute. Costs 1 Mon.")
-            .addField("**Obliterate** (.eco buy obliterate @user)", "Call upon the demons of Selzar to blast a person of your choice with a laser so powerful that it prevents them from using TravBot for 2 entire days. Costs 15 Mons.")
             .setFooter("Mon Shop | TravBot Services");
         message.channel.send(embed);
     }

--- a/commands/eco.js
+++ b/commands/eco.js
@@ -214,7 +214,7 @@ exports.run = async (client, message, args, level) => {
             .addField("**Hug** (.eco buy hug)", "Hug Monika. Costs 1 Mon.")
             .addField("**Handholding** (.eco buy handhold)", "Hold Monika's hand. Costs 2 Mons.")
             .addField("**Cute** (.eco buy cute)", "Calls Monika cute. Costs 1 Mon.")
-            .addField("**Obliterate** (.eco buy obliterate @user)", "Call upon the demons of Selzar to blast a person of your choice with a laser so powerful that it prevents them from using TravBot for 3 entire days. Costs 15 Mons.")
+            .addField("**Obliterate** (.eco buy obliterate @user)", "Call upon the demons of Selzar to blast a person of your choice with a laser so powerful that it prevents them from using TravBot for 2 entire days. Costs 15 Mons.")
             .setFooter("Mon Shop | TravBot Services");
         message.channel.send(embed);
     }

--- a/commands/insult.js
+++ b/commands/insult.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-unused-vars */
+exports.run = async (client, message, args, level) => {
+    message.channel.startTyping();
+    setTimeout(() => {
+        message.channel.send("What the fuck did you just fucking say about me, you little bitch? I'll have you know I graduated top of my class in the Navy Seals, and I've been involved in numerous secret raids on Al-Quaeda, and I have over 300 confirmed kills. I am trained in gorilla warfare and I'm the top sniper in the entire US armed forces. You are nothing to me but just another target. I will wipe you the fuck out with precision the likes of which has never been seen before on this Earth, mark my fucking words. You think you can get away with saying that shit to me over the Internet? Think again, fucker. As we speak I am contacting my secret network of spies across the USA and your IP is being traced right now so you better prepare for the storm, maggot. The storm that wipes out the pathetic little thing you call your life. You're fucking dead, kid. I can be anywhere, anytime, and I can kill you in over seven hundred ways, and that's just with my bare hands. Not only am I extensively trained in unarmed combat, but I have access to the entire arsenal of the United States Marine Corps and I will use it to its full extent to wipe your miserable ass off the face of the continent, you little shit. If only you could have known what unholy retribution your little \"clever\" comment was about to bring down upon you, maybe you would have held your fucking tongue. But you couldn't, you didn't, and now you're paying the price, you goddamn idiot. I will shit fury all over you and you will drown in it. You're fucking dead, kiddo.");
+        message.channel.stopTyping();
+    }, 60000);
+};
+exports.conf = {
+    enabled: true,
+    guildOnly: false,
+    aliases: [],
+    permLevel: "User"
+};
+exports.help = {
+    name: "insult",
+    category: "Fun",
+    description: "Insult TravBot! >:D",
+    usage: "insult"
+};

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -1,10 +1,6 @@
 /* eslint-disable no-unused-vars */
 exports.run = async (client, message, args, level) => {
-    if (args[0]) {
-        message.channel.send(`https://discordapp.com/api/oauth2/authorize?client_id=606395763404046349&permissions=${args[0]}&scope=bot`);
-    } else {
-        message.channel.send("https://discordapp.com/api/oauth2/authorize?client_id=606395763404046349&permissions=8&scope=bot");
-    }
+    message.channel.send(`https://discordapp.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=${args[0] || 8}&scope=bot`);
 };
 exports.conf = {
     enabled: true,

--- a/commands/scanemotes.js
+++ b/commands/scanemotes.js
@@ -1,47 +1,101 @@
 /* eslint-disable no-unused-vars */
+const moment = require("moment");
 exports.run = async (client, message, args, level) => {
+    // Test if the command is on cooldown. This isn't the strictest cooldown possible, because in the event that the bot crashes, the cooldown will be reset. But for all intends and purposes, it's a good enough cooldown. It's a per-server cooldown.
+    if (!("scanemotesCooldown" in client)) client.scanemotesCooldown = {};
+    const cooldown = 3600000; // 1 hour
+    const lastUsedTimestamp = client.scanemotesCooldown[message.guild.id] || 0;
+    const difference = Date.now() - lastUsedTimestamp;
+    const howLong = moment(Date.now()).to(lastUsedTimestamp + cooldown);
+
+    // If it's been less than an hour since the command was last used, prevent it from executing.
+    if (difference < cooldown) {
+        message.channel.send(`This command requires an hour to cooldown. You'll be able to activate this command ${howLong}.`);
+        return;
+    }
+
     let stats = {};
     let statsWithoutBots = {};
-    let allTextChannelsInCurrentGuild = message.guild.channels.filter(channel => channel.type === "text");
-    let limit = allTextChannelsInCurrentGuild.size;
-    let channelsSearched = 0;
-
-    allTextChannelsInCurrentGuild.forEach(async channel => {
+    let allTextChannelsInCurrentGuild = message.guild.channels.filter(channel => {
         // IMPORTANT: You MUST check if the bot actually has access to the channel in the first place. It will get the list of all channels, but that doesn't mean it has access to every channel. Without this, it'll require admin access and throw an annoying unhelpful DiscordAPIError: Missing Access otherwise.
         const permissions = channel.permissionsFor(client.user);
         const isViewable = permissions && permissions.has("VIEW_CHANNEL", false);
-        
-        if (!isViewable) {
-            limit--;
-            return;
-        }
-        
-        // This will count all reactions in text and reactions per channel.
-        let selected = channel.lastMessageID;
-        let continueLoop = true;
+        return channel.type === "text" && isViewable;
+    });
+    let limit = allTextChannelsInCurrentGuild.size;
+    let channelsSearched = 0;
+    let statusMessage = await message.channel.send("Gathering emotes...");
+    let lastChannelID;
+    message.channel.startTyping();
 
-        while (continueLoop) {
-            let messages = await channel.fetchMessages({
-                limit: 100,
-                before: selected
-            });
+    try {
+        allTextChannelsInCurrentGuild.forEach(async channel => {
+            // This will count all reactions in text and reactions per channel.
+            let selected = channel.lastMessageID;
+            let continueLoop = true;
 
-            if (messages.size <= 0) {
-                continueLoop = false;
-                channelsSearched++;
+            while (continueLoop) {
+                let messages = await channel.fetchMessages({
+                    limit: 100,
+                    before: selected
+                });
 
-                // Display stats on emote usage.
-                if (channelsSearched >= limit) {
-                    // Depending on how many emotes you have, you might have to break up the analytics into multiple messages.
-                    let lines = [];
-                    let line = "";
+                // The reason why I place the status update here is because searching through channels is asynchronous, so different channels will be searched randomly.
+                // To avoid setting off Discord's rate limits like crazy, it'll only send an edit request if the channel is different.
+                // Also, I check if there are 100 or more messages in a given channel to avoid small channels like info channels.
+                if (channel.id !== lastChannelID && messages.size >= 100) statusMessage.edit(`Searching channel \`${channel.name}\`...`);
+                lastChannelID = channel.id;
 
-                    for (let emote in stats) {
-                        let emoteObject = message.guild.emojis.get(emote);
+                if (messages.size <= 0) {
+                    continueLoop = false;
+                    channelsSearched++;
 
-                        // Emotes not within the current guild (or deleted ones) will return null. Select only those from the current guild.
-                        if (emoteObject != null) {
-                            let stat = emoteObject.toString() + " x " + stats[emote] + " (" + (statsWithoutBots[emote] || 0) + " without bots)\n";
+                    // Display stats on emote usage.
+                    if (channelsSearched >= limit) {
+                        // Make sure to activate the cooldown before any return statements.
+                        client.scanemotesCooldown[message.guild.id] = Date.now();
+
+                        // If there are no emotes to track, send that instead.
+                        if (Object.keys(stats).length === 0) {
+                            message.channel.send("There are no emotes to analyze!");
+                            message.channel.stopTyping();
+                            return;
+                        }
+
+                        // Depending on how many emotes you have, you might have to break up the analytics into multiple messages.
+                        let total = 0;
+                        let validEmotes = [];
+                        let lines = [];
+                        let line = "";
+
+                        for (let emote in stats) {
+                            let emoteObject = message.guild.emojis.get(emote);
+
+                            // Emotes not within the current guild (or deleted ones) will return null. Select only those from the current guild.
+                            if (emoteObject != null) {
+                                let stat = `<:${emoteObject.name}:${emote}> x ${stats[emote]} (${statsWithoutBots[emote] || 0} w/o bots)\n`;
+                                total += statsWithoutBots[emote];
+                                validEmotes.push(emote);
+
+                                if (line.length + stat.length > 2000) {
+                                    lines.push(line);
+                                    line = "";
+                                }
+
+                                line += stat;
+                            }
+                        }
+
+                        // It's better to send all the lines at once rather than paginate the data because it's quite a memory-intensive task to search all the messages in a server for it, and I wouldn't want to activate the command again just to get to another page.
+                        if (line.length > 0) lines.push(line); // You can't send empty messages or there'll be an error.
+                        
+                        // Do the same thing but sorted and with percentages.
+                        let sorted = validEmotes.sort((a, b) => statsWithoutBots[b] - statsWithoutBots[a]);
+                        let rank = 1;
+                        line = "";
+
+                        for (let emote of sorted) {
+                            let stat = `#${rank++} <:${message.guild.emojis.get(emote).name}:${emote}> - ${(statsWithoutBots[emote] / total * 100).toFixed(3)}%\n`;
 
                             if (line.length + stat.length > 1900) {
                                 lines.push(line);
@@ -50,52 +104,56 @@ exports.run = async (client, message, args, level) => {
 
                             line += stat;
                         }
+
+                        if (line.length > 0) lines.push(line);
+                        for (let ln of lines) await message.channel.send(ln);
+                        statusMessage.delete();
+                        message.channel.stopTyping();
                     }
+                } else {
+                    messages.forEach(msg => {
+                        let msgEmotes = msg.content.match(/<:.+?:\d+?>/g) || [];
+                        let reactionEmotes = msg.reactions.keyArray();
 
-                    if (line.length > 0) lines.push(line); // You can't send empty messages or there'll be an error.
-                    for (let ln of lines) await message.channel.send(ln);
-                }
-            } else {
-                messages.forEach(msg => {
-                    let msgEmotes = msg.content.match(/<:.+?:\d+?>/g) || [];
-                    let reactionEmotes = msg.reactions.keyArray();
+                        for (let emote of msgEmotes) {
+                            let emoteID = emote.match(/\d+/g)[0];
 
-                    for (let emote of msgEmotes) {
-                        let emoteID = emote.match(/\d+/g)[0];
-
-                        if (!(emoteID in stats)) stats[emoteID] = 0;
-                        stats[emoteID]++;
-
-                        if (!msg.author.bot) {
-                            if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
-                            statsWithoutBots[emoteID]++;
-                        }
-                    }
-
-                    for (let emoteTag of reactionEmotes) {
-                        let emoteTagIndex = emoteTag.indexOf(":");
-                        let emoteID = emoteTagIndex !== -1 ? emoteTag.substring(emoteTagIndex + 1) : emoteTag; // In Discord.js v11, the keys are "<emote name>:<emote ID>" instead.
-
-                        // Exclude any unicode emote.
-                        if (msg.reactions.get(emoteTag).emoji.id != null) {
                             if (!(emoteID in stats)) stats[emoteID] = 0;
-                            stats[emoteID] += msg.reactions.get(emoteTag).count;
+                            stats[emoteID]++;
 
-                            if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
-                            statsWithoutBots[emoteID] += msg.reactions.get(emoteTag).count;
-
-                            // I don't know why this collection always appears as empty.
-                            msg.reactions.get(emoteTag).users.forEach(user => {
-                                if (user.bot) statsWithoutBots[emoteID]--;
-                            });
+                            if (!msg.author.bot) {
+                                if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
+                                statsWithoutBots[emoteID]++;
+                            }
                         }
-                    }
 
-                    selected = msg.id;
-                });
+                        for (let emoteTag of reactionEmotes) {
+                            let emoteTagIndex = emoteTag.indexOf(":");
+                            let emoteID = emoteTagIndex !== -1 ? emoteTag.substring(emoteTagIndex + 1) : emoteTag; // In Discord.js v11, the keys are "<emote name>:<emote ID>" instead.
+
+                            // Exclude any unicode emote.
+                            if (msg.reactions.get(emoteTag).emoji.id != null) {
+                                if (!(emoteID in stats)) stats[emoteID] = 0;
+                                stats[emoteID] += msg.reactions.get(emoteTag).count;
+
+                                if (!(emoteID in statsWithoutBots)) statsWithoutBots[emoteID] = 0;
+                                statsWithoutBots[emoteID] += msg.reactions.get(emoteTag).count;
+
+                                // I don't know why this collection always appears as empty.
+                                msg.reactions.get(emoteTag).users.forEach(user => {
+                                    if (user.bot) statsWithoutBots[emoteID]--;
+                                });
+                            }
+                        }
+
+                        selected = msg.id;
+                    });
+                }
             }
-        }
-    });
+        });
+    } catch (error) {
+        message.channel.send("```" + error + "```");
+    }
 };
 exports.conf = {
     enabled: true,

--- a/config.js.example
+++ b/config.js.example
@@ -30,7 +30,14 @@ const config = {
   // PERMISSION LEVEL DEFINITIONS.
 
   permLevels: [
-    // This is the lowest permisison level, this is for non-roled users.
+    // There's one special permission level below users, which is when the selected user has been obliterated via the eco command. This prevents them from using TravBot for 2 days.
+    { level: -1,
+      name: "Obliterated",
+      // As with below, being obliterated will prevent the user from using any command, so just return false.
+      check: () => false
+    },
+
+    // This is the lowest permission level, this is for non-roled users.
     { level: 0,
       name: "User", 
       // Don't bother checking, just return true which allows them to execute any command their

--- a/config.js.example
+++ b/config.js.example
@@ -30,13 +30,6 @@ const config = {
   // PERMISSION LEVEL DEFINITIONS.
 
   permLevels: [
-    // There's one special permission level below users, which is when the selected user has been obliterated via the eco command. This prevents them from using TravBot for 2 days.
-    { level: -1,
-      name: "Obliterated",
-      // As with below, being obliterated will prevent the user from using any command, so just return false.
-      check: () => false
-    },
-
     // This is the lowest permission level, this is for non-roled users.
     { level: 0,
       name: "User", 

--- a/config_base.txt
+++ b/config_base.txt
@@ -13,13 +13,6 @@ const config = {
 
   // PERMISSION LEVEL DEFINITIONS.
   permLevels: [
-    // There's one special permission level below users, which is when the selected user has been obliterated via the eco command. This prevents them from using TravBot for 2 days.
-    { level: -1,
-      name: "Obliterated",
-      // As with below, being obliterated will prevent the user from using any command, so just return false.
-      check: () => false
-    },
-
     // This is the lowest permisison level, this is for non-roled users.
     { level: 0,
       name: "User", 

--- a/config_base.txt
+++ b/config_base.txt
@@ -13,6 +13,13 @@ const config = {
 
   // PERMISSION LEVEL DEFINITIONS.
   permLevels: [
+    // There's one special permission level below users, which is when the selected user has been obliterated via the eco command. This prevents them from using TravBot for 2 days.
+    { level: -1,
+      name: "Obliterated",
+      // As with below, being obliterated will prevent the user from using any command, so just return false.
+      check: () => false
+    },
+
     // This is the lowest permisison level, this is for non-roled users.
     { level: 0,
       name: "User", 

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -1,31 +1,6 @@
 const Discord = require("discord.js");
-const moment = require("moment");
-const fs = require("fs");
 module.exports = client => {
    client.permlevel = message => {
-      // Check if the user has been obliterated and hasn't recovered yet.
-      const UserData = JSON.parse(fs.readFileSync("commands/storage/UserData.json", "utf-8"));
-      const compositeID = message.author.id + message.guild.id;
-      if (!UserData[compositeID]) UserData[compositeID] = {};
-      if (UserData[compositeID].obliterated) {
-         const cooldown = 172800000; // 2 days
-         const obliteratedTimestamp = UserData[compositeID].obliterated;
-         const now = Date.now();
-         const difference = now - obliteratedTimestamp;
-
-         // If the user is still obliterated, return -1, otherwise return their normal permission level.
-         if (difference < cooldown) {
-            const howLong = moment(now).to(obliteratedTimestamp + cooldown);
-            message.channel.send(`Being obliterated prevents you from using TravBot in this server for 2 days. You'll be able to use TravBot again in ${howLong}.`);
-            return -1;
-         } else {
-            delete UserData[compositeID].obliterated;
-            fs.writeFileSync("commands/storage/UserData.json", JSON.stringify(UserData), err => {
-               if (err) console.log(err);
-            });
-         }
-      }
-
       let permlvl = 0;
       const permOrder = client.config.permLevels.slice(0)
          .sort(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.5.0",
+    "version": "2.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.6.1",
+    "version": "2.7.0",
     "description": "TravBot Discord bot.",
     "main": "index.js",
     "author": "Keanu",


### PR DESCRIPTION
# Major Changes
- Added an hour long cooldown to `scanemotes` per server because it's a very memory-intensive task to search through every single message.
- Added a second list of emotes to `scanemotes`, sorting by percentage of users-only usage.
- Added a function to the client's common functions to generate a page users can turn.

# Minor Changes
- `avatar`
	- Now has proper error handling when searching by mention and ID.
	- No longer pings the user, it just sends the image link by itself.
- `eco`
	- Merges `sender.id + message.guild.id` into `compositeID` since it's so frequently used.
	- Bug Fix: If you have exactly 1 Mon and you pay someone 1 Mon, they'll get 1 more Mon and you'll still have 1 Mon because the 0 coerces to false resetting your money, because JS soft comparison. Fixed by using the "in" operator instead.
	- Uses else ifs to make the command marginally faster.
	- Now properly handles mentions and extracting the user ID from them in the `pay` subcommand.
	- Added a message that occurs when the user tries to buy an item that doesn't exist.
- Added an `insult` command which will have the bot type out the navy seals copypasta for a minute.
- Modified the `invite` command to auto-generate a link based on the current bot client ID rather than having it be hardcoded to TravBot specifically.
- Added error checking to `scanemotes` so users aren't left in the dark if something happens.
- On big servers, `scanemotes` should now have emotes actually show up.