### PR TITLE
Reworked the react command (v2.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 	- Renamed guild ID to message ID for clarity's sake.
 	- Now removes the bot's own reaction after a few seconds to make the reaction count more accurate.
 	- Now lets you react with multiple messages in a row.
+	- Now reacts with ❓ if no reactions were found at all (see below).
 - `emote`:
 	- Is now case-sensitive again (because there are too many name conflicts).
 	- Accepts multiple emotes for tiled emotes.
+	- Now reacts to your message with ❓ instead of `None of those emote names were valid!` so that the bot doesn't spam the chat if you can't find the right emote (because you'll still be able to delete your messages).
 - `thonk` now stores the last specified phrase so you can repeat a phrase with different diacritics.
 
 # 2.8.3 - The ultimate meme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.8.4 - Reworked the react command
+- `react` is now a fully versatile command for helping you react to other messages with non-server emotes.
+	- Now properly reacts to the previous message (bug fix).
+	- Provides you the option to react to any number of messages before your message (3 messages above yours for example).
+	- Renamed guild ID to message ID for clarity's sake.
+	- Now removes the bot's own reaction after a few seconds to make the reaction count more accurate.
+	- Now lets you react with multiple messages in a row.
+- `emote`:
+	- Is now case-sensitive again (because there are too many name conflicts).
+	- Accepts multiple emotes for tiled emotes.
+- `thonk` now stores the last specified phrase so you can repeat a phrase with different diacritics.
+
+# 2.8.3 - The ultimate meme
+
 # 2.8.2
 - Added a changelog.
 - Added an extra instruction to the readme's installation.

--- a/commands/emote.js
+++ b/commands/emote.js
@@ -16,8 +16,11 @@ exports.run = async (client, message, args, level) => {
         }
     }
 
-    message.delete();
-    message.channel.send(foundAny ? text : "None of those emote names were valid!");
+    if (foundAny) {
+        message.channel.send(text);
+        message.delete();
+    } else
+        message.react("❓");
 };
 exports.conf = {
     enabled: true,

--- a/commands/emote.js
+++ b/commands/emote.js
@@ -1,11 +1,23 @@
 /* eslint-disable no-unused-vars */
 exports.run = async (client, message, args, level) => {
     if (!args[0]) return message.channel.send("You need to specify an emote to use!");
-    const search = args[0].toLowerCase();
-    const emote = client.emojis.find(emote => emote.name.toLowerCase().includes(search));
-    if (!emote) return message.channel.send("That's not a valid emote name!");
+    let text = "";
+    let foundAny = false;
+
+    for (const search of args) {
+        if (search === "\\")
+            text += "\n";
+        else {
+            const emote = client.emojis.find(emote => emote.name === search);
+            text += emote ? emote.toString() : "❓";
+
+            if (emote)
+                foundAny = true;
+        }
+    }
+
     message.delete();
-    message.channel.send(`${emote}`);
+    message.channel.send(foundAny ? text : "None of those emote names were valid!");
 };
 exports.conf = {
     enabled: true,
@@ -16,6 +28,6 @@ exports.conf = {
 exports.help = {
     name: "emote",
     category: "Fun",
-    description: "Sends an emote.",
-    usage: "emote [emote name]"
+    description: "Sends any amount of emotes. Include a backslash in place of an emote's name if you want a new line.",
+    usage: "emote [emote name(s)]"
 };

--- a/commands/react.js
+++ b/commands/react.js
@@ -43,6 +43,8 @@ exports.run = async (client, message, args, level) => {
         const emoji = client.emojis.find(emoji => emoji.name === search);
 
         if (emoji) {
+            // Call the delete function only once to avoid unnecessary errors.
+            if (!anyEmoteIsValid) message.delete();
             anyEmoteIsValid = true;
             const reaction = await target.react(emoji);
 
@@ -53,8 +55,7 @@ exports.run = async (client, message, args, level) => {
         }
     }
 
-    if (!anyEmoteIsValid)
-        message.react("❓");
+    if (!anyEmoteIsValid && !message.deleted) message.react("❓");
 };
 exports.conf = {
     enabled: true,
@@ -65,6 +66,6 @@ exports.conf = {
 exports.help = {
     name: "react",
     category: "Fun",
-    description: "Reacts to the previous message.",
+    description: "Reacts to the a previous message in your place. You have to react with the same emote before the bot removes that reaction.",
     usage: "react <emote name> (<message ID / distance>)"
 };

--- a/commands/react.js
+++ b/commands/react.js
@@ -1,28 +1,55 @@
 /* eslint-disable no-unused-vars */
 exports.run = async (client, message, args, level) => {
-    const guildID = args[1];
-    const emoji = client.emojis.find(emoji => emoji.name === args[0]);
-    if (!emoji) return message.channel.send("Please provide a valid emote name!");
-    if (!guildID) {
-        message.channel.fetchMessages({
-            limit: 1
-        }).then(messages => {
-            const lastMessage = messages.first();
-            message.channel.fetchMessage(lastMessage)
-                .then(function(message) {
-                    message.react(emoji);
-                }).catch((err) => {
-                    console.log(err);
-                });
-        });
-    } else {
-        message.channel.fetchMessage(guildID)
-            .then(function(message) {
-                message.react(emoji);
-            }).catch((err) => {
-                console.log(err);
-            });
+    if (args.length === 0) return message.channel.send("Please provide a valid emote name!");
+
+    let target;
+
+    if (args.length >= 2) {
+        const last = args[args.length - 1];
+
+        if (/\d{17,19}/g.test(last)) {
+            try {
+                target = await message.channel.fetchMessage(last)
+            } catch {
+                return message.channel.send(`No valid message found by the ID \`${last}\`!`)
+            }
+            args.pop();
+        }
+        // The entire string has to be a number for this to match. Prevents leaCheeseAmerican1 from triggering this.
+        else if (/^\d+$/g.test(last)) {
+            const distance = parseInt(last);
+
+            if (distance >= 0 && distance <= 99) {
+                // Messages are ordered from latest to earliest.
+                target = (await message.channel.fetchMessages({
+                    limit: distance + 1
+                })).last();
+                args.pop();
+            } else
+                return message.channel.send("Your distance must be between 0 and 99!");
+        }
     }
+
+    // distance = 1
+    if (!target) {
+        target = (await message.channel.fetchMessages({
+            limit: 2
+        })).last();
+    }
+
+    for (const search of args) {
+        const emoji = client.emojis.find(emoji => emoji.name === search);
+
+        if (emoji) {
+            const reaction = await target.react(emoji);
+
+            // This part is called with a promise because you don't want to wait 5 seconds between each reaction.
+            client.wait(5000).then(() => {
+                reaction.remove(client.user);
+            });
+        }
+    }
+
 };
 exports.conf = {
     enabled: true,
@@ -34,5 +61,5 @@ exports.help = {
     name: "react",
     category: "Fun",
     description: "Reacts to the previous message.",
-    usage: "react [guild id] <emote name>"
+    usage: "react <emote name> (<message ID / distance>)"
 };

--- a/commands/react.js
+++ b/commands/react.js
@@ -3,6 +3,7 @@ exports.run = async (client, message, args, level) => {
     if (args.length === 0) return message.channel.send("Please provide a valid emote name!");
 
     let target;
+    let distance = 1;
 
     if (args.length >= 2) {
         const last = args[args.length - 1];
@@ -17,23 +18,18 @@ exports.run = async (client, message, args, level) => {
         }
         // The entire string has to be a number for this to match. Prevents leaCheeseAmerican1 from triggering this.
         else if (/^\d+$/g.test(last)) {
-            const distance = parseInt(last);
+            distance = parseInt(last);
 
-            if (distance >= 0 && distance <= 99) {
-                // Messages are ordered from latest to earliest.
-                target = (await message.channel.fetchMessages({
-                    limit: distance + 1
-                })).last();
-                args.pop();
-            } else
-                return message.channel.send("Your distance must be between 0 and 99!");
+            if (distance >= 0 && distance <= 99) args.pop();
+            else return message.channel.send("Your distance must be between 0 and 99!");
         }
     }
 
-    // distance = 1
     if (!target) {
+        // Messages are ordered from latest to earliest.
+        // You also have to add 1 as well because fetchMessages includes your own message.
         target = (await message.channel.fetchMessages({
-            limit: 2
+            limit: distance + 1
         })).last();
     }
 
@@ -44,7 +40,7 @@ exports.run = async (client, message, args, level) => {
 
         if (emoji) {
             // Call the delete function only once to avoid unnecessary errors.
-            if (!anyEmoteIsValid) message.delete();
+            if (!anyEmoteIsValid && distance !== 0) message.delete();
             anyEmoteIsValid = true;
             const reaction = await target.react(emoji);
 

--- a/commands/react.js
+++ b/commands/react.js
@@ -37,10 +37,13 @@ exports.run = async (client, message, args, level) => {
         })).last();
     }
 
+    let anyEmoteIsValid = false;
+
     for (const search of args) {
         const emoji = client.emojis.find(emoji => emoji.name === search);
 
         if (emoji) {
+            anyEmoteIsValid = true;
             const reaction = await target.react(emoji);
 
             // This part is called with a promise because you don't want to wait 5 seconds between each reaction.
@@ -50,6 +53,8 @@ exports.run = async (client, message, args, level) => {
         }
     }
 
+    if (!anyEmoteIsValid)
+        message.react("❓");
 };
 exports.conf = {
     enabled: true,

--- a/commands/thonk.js
+++ b/commands/thonk.js
@@ -27,12 +27,12 @@ function transform(str) {
 
     return out;
 }
+
+let phrase = "I have no currently set phrase!";
+
 exports.run = async (client, message, args, level) => {
-    if (args.length > 0) {
-        message.channel.send(transform(args.join(" ")));
-    } else {
-        message.channel.send("You need to send at least one argument!");
-    }
+    if (args.length > 0) phrase = args.join(" ");
+    message.channel.send(transform(phrase));
 };
 exports.conf = {
     enabled: true,
@@ -44,5 +44,5 @@ exports.help = {
     name: "thonk",
     category: "Fun",
     description: "Transforms your text into ｖｉｅｔｎａｍｅｓｅ.",
-    usage: "thonk [text]"
+    usage: "thonk ([text])"
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.8.2",
+    "version": "2.8.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "travebot",
-    "version": "2.8.2",
+    "version": "2.8.4",
     "description": "TravBot Discord bot.",
     "main": "index.js",
     "author": "Keanu",


### PR DESCRIPTION
- `react` is now a fully versatile command for helping you react to other messages with non-server emotes.
	- Now properly reacts to the previous message (bug fix).
	- Provides you the option to react to any number of messages before your message (3 messages above yours for example).
	- Renamed guild ID to message ID for clarity's sake.
	- Now removes the bot's own reaction after a few seconds to make the reaction count more accurate.
	- Now lets you react with multiple messages in a row.
- `emote`:
	- Is now case-sensitive again (because there are too many name conflicts).
	- Accepts multiple emotes for tiled emotes.
- `thonk` now stores the last specified phrase so you can repeat a phrase with different diacritics.